### PR TITLE
feat: make code & language accessible for custom layout

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -19,8 +19,13 @@
       :delay="2000"
     />
     <h2>Default Layout</h2>
-    <div style="width:950px; width:950px; max-width:95vw; margin:20px auto;">
+    <div style="width:950px; max-width:95vw; margin:20px auto;">
       <VueLive :code="`<input type='button' value='I am Groot' />`"/>
+    </div>
+    <h2>Custom Layout</h2>
+    <div>
+      <p>Attributes available for custom layout: <code>code: String</code>, <code>language: String</code></p>
+      <VueLive :code="`<input type='button' value='I am Groot' />`" :layout="CustomLayout"/>
     </div>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
   </main>

--- a/src/VueLive.vue
+++ b/src/VueLive.vue
@@ -1,5 +1,5 @@
 <template>
-  <component :is="layout ? layout : VueLiveDefaultLayout">
+  <component :is="layout ? layout : VueLiveDefaultLayout" :code="stableCode" :language="prismLang">
     <template v-slot:editor>
       <PrismEditor v-model="stableCode" @change="updatePreview" :language="prismLang"/>
     </template>


### PR DESCRIPTION
Hi @elevatebart! 
I appreciate your work for this repo and whole ecosystem (`vue-docgen-api`, `vue-inbrowser-compiler`, etc...), big thanks for that!

Please consider about this PR, this could be helpful for cases like mine, where I need to have an access to `code` and `lang` in my wrapper, because I need to do a bit more things in the view.

Cheers!