### PR TITLE
feat: make requires & components accessible for custom layout

### DIFF
--- a/demo/App.vue
+++ b/demo/App.vue
@@ -24,7 +24,11 @@
     </div>
     <h2>Custom Layout</h2>
     <div>
-      <p>Attributes available for custom layout: <code>code: String</code>, <code>language: String</code></p>
+      <p>Attributes available for custom layout: </p>
+      <p>
+        <code>code: String</code>, <code>language: String</code>,
+        <code>components: Object</code>, <code>requires: Object</code>
+      </p>
       <VueLive :code="`<input type='button' value='I am Groot' />`" :layout="CustomLayout"/>
     </div>
     <link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">

--- a/src/VueLive.vue
+++ b/src/VueLive.vue
@@ -1,5 +1,11 @@
 <template>
-  <component :is="layout ? layout : VueLiveDefaultLayout" :code="stableCode" :language="prismLang">
+  <component
+    :is="layout ? layout : VueLiveDefaultLayout"
+    :code="stableCode"
+    :language="prismLang"
+    :requires="requires"
+    :components="components"
+  >
     <template v-slot:editor>
       <PrismEditor v-model="stableCode" @change="updatePreview" :language="prismLang"/>
     </template>


### PR DESCRIPTION
Hi again!

During development of some `vuepress` plugins I discovered that in custom layout `requires` and `components` props are not accessible. In this PR I added these two props to dynamic component as well. I also extended demo website.

It would be great if You will accept and merge this PR.

Thank you!