### PR TITLE
chore: update vue-prism-editor version

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,34 @@ export default {
 
 Check out the [demo](http://vue-live.surge.sh) for alernative syntaxes to write your showcases.
 
+## Configuration
+
+```js
+module.exports = {
+  // ...
+  plugins: [
+    [
+      'live',
+      {
+        // to use a custom layout for your vue components
+        layout: path.resolve(__dirname, "../custom-layout")
+      }
+    ],
+    [
+      "@vuepress/register-components",
+      {
+        components: [
+          {
+            name: "vue-slider",
+            path: path.resolve(__dirname, "../vue-slider")
+          }
+        ]
+      }
+    ]
+  ]
+}
+```
+
 ## How to contribute
 
 ```sh

--- a/package-lock.json
+++ b/package-lock.json
@@ -1375,8 +1375,7 @@
       "version": "7.0.7",
       "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.7.tgz",
       "integrity": "sha512-dBtBbrc+qTHy1WdfHYjBwRln4+LWqASWakLHsWHR2NWHIFkv4W3O070IGoGLEBrJBvct3r0L1BUPuvURi7kYUQ==",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "@types/babel__core": {
       "version": "7.1.2",
@@ -1424,7 +1423,6 @@
       "resolved": "https://registry.npmjs.org/@types/babylon/-/babylon-6.16.5.tgz",
       "integrity": "sha512-xH2e58elpj1X4ynnKp9qSnWlsRTIs6n3tgLGNfwAGHwePw0mulHQllV34n0T25uYSu1k0hRKkWXF890B1yS47w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@types/babel-types": "*"
       }
@@ -2509,7 +2507,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -2521,7 +2518,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -4577,8 +4573,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "consolidate": {
       "version": "0.15.1",
@@ -4594,7 +4589,6 @@
       "resolved": "https://registry.npmjs.org/constantinople/-/constantinople-3.1.2.tgz",
       "integrity": "sha512-yePcBqEFhLOqSBtwYOGGS1exHo/s1xjekXiinh4itpNQGCu4KA1euPh1fg07N2wMITZXQkBz75Ntdt1ctGZouw==",
       "dev": true,
-      "optional": true,
       "requires": {
         "@types/babel-types": "^7.0.0",
         "@types/babylon": "^6.16.2",
@@ -8333,8 +8327,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "figures": {
           "version": "2.0.0",
@@ -8369,7 +8362,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^3.0.0"
           }
@@ -12194,8 +12186,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/js-stringify/-/js-stringify-1.0.2.tgz",
       "integrity": "sha1-Fzb939lyTyijaCrcYjCufk6Weds=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -12973,8 +12964,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -13380,7 +13370,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -15335,8 +15324,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/pug-error/-/pug-error-1.3.2.tgz",
       "integrity": "sha1-U659nSm7A89WRJOgJhCfVMR/XyY=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pug-filters": {
       "version": "3.1.0",
@@ -15456,8 +15444,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/pug-runtime/-/pug-runtime-2.0.4.tgz",
       "integrity": "sha1-4XjhvaaKsujArPybztLFT9iM61g=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pug-strip-comments": {
       "version": "1.0.3",
@@ -15473,8 +15460,7 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/pug-walk/-/pug-walk-1.1.7.tgz",
       "integrity": "sha1-wA1cUSi6xYBr7BXSt+fNq+QlMfM=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "pump": {
       "version": "3.0.0",
@@ -16304,8 +16290,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
       "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "rx-lite-aggregates": {
       "version": "4.0.8",
@@ -17414,8 +17399,7 @@
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
@@ -18433,9 +18417,9 @@
       }
     },
     "vue-prism-editor": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/vue-prism-editor/-/vue-prism-editor-0.2.1.tgz",
-      "integrity": "sha512-8hyO9TwH9dZFws8f6+9tKT3ag3B5eK5MJu8cI1QFTYFNJKKz8Hymbr/aVMBYIQrNsZJmlxJxKKR/GiF5s88dPg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/vue-prism-editor/-/vue-prism-editor-0.3.0.tgz",
+      "integrity": "sha512-yNSuwql/xHMJrWghn/OhZ5WPBKdhx7FkvFjgq2uDm99jHSJhuGwhcgPyuoGzpm6w8DRDzi85lgerKCu8DTDWWg==",
       "requires": {
         "dom-iterator": "^1.0.0",
         "escape-html": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "core-js": "^2.6.5",
     "debounce": "^1.2.0",
     "prismjs": "^1.16.0",
-    "vue-prism-editor": "^0.3.0"
     "vue-inbrowser-compiler": "^3.21.0",
+    "vue-prism-editor": "^0.3.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "debounce": "^1.2.0",
     "prismjs": "^1.16.0",
     "vue-inbrowser-compiler": "^3.16.3",
-    "vue-prism-editor": "^0.2.1"
+    "vue-prism-editor": "^0.3.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.9.2",


### PR DESCRIPTION
Updates prism editor to the [latest](https://github.com/koca/vue-prism-editor/releases/tag/v.0.3.0) release after highlighting [fix](https://github.com/koca/vue-prism-editor/pull/31) from @elevatebart :)

Should hopefully close #20 