### PR TITLE
feat: Added prop dataScope for use outside data to the preview

### DIFF
--- a/src/Preview.vue
+++ b/src/Preview.vue
@@ -49,6 +49,14 @@ export default {
     jsx: {
       type: Boolean,
       default: false
+    },
+    /**
+     * Outside data to the preview
+     * @example { count: 1 }
+     */
+    dataScope: {
+      type: Object,
+      default: () => {}
     }
   },
   data() {
@@ -109,6 +117,11 @@ export default {
               adaptCreateElement,
               concatenate
             ) || {};
+
+          if (this.dataScope) {
+            const mergeData = { ...data.data(), ...this.dataScope  };
+            data.data = () => mergeData;
+          }
         }
         if (renderedComponent.template) {
           // if this is a pure template or if we are in hybrid vsg mode,

--- a/src/VueLive.vue
+++ b/src/VueLive.vue
@@ -6,6 +6,7 @@
     :language="lang"
     :prismLang="prismLang"
     :requires="requires"
+    :data-scope="dataScope"
     :components="components"
   >
     <template v-slot:editor>
@@ -25,6 +26,7 @@
         :components="components"
         :requires="requires"
         :jsx="jsx"
+        :data-scope="dataScope"
       />
     </template>
   </component>
@@ -110,6 +112,14 @@ export default {
     editorProps: {
       type: Object,
       default: () => ({})
+    },
+    /**
+     * Outside data to the preview
+     * @example { count: 1 }
+     */
+    dataScope: {
+      type: Object,
+      default: () => {}
     }
   },
   data() {


### PR DESCRIPTION
Suppose I get a line of code with data from the store(Vuex) and want to show only the component code without a script section. This edit allows you to do this through the data-scope property