### PR TITLE
feat: updated regex validation of element attributes to enable 'aria-…

### DIFF
--- a/src/utils/checkTemplate.js
+++ b/src/utils/checkTemplate.js
@@ -49,7 +49,7 @@ export default function($options, checkVariableAvailability) {
       const templateVars = [];
       if (templateAst.type === ELEMENT) {
         templateAst.props.forEach((attr) => {
-          if (!/^[a-z,-,:]+$/g.test(attr.name)) {
+          if (!/^[a-z-:]+$/g.test(attr.name)) {
             throw new VueLiveParseTemplateAttrError(
               "[VueLive] Invalid attribute name: " + attr.name,
               attr.loc


### PR DESCRIPTION
I just noticed that attributes like 'aria-label' are invalid on HTML elements.
Therefore I've adjusted the regex to validate attributes to accept "a-z" and "-" and ":"