### PR TITLE
fix: should use the safe removal method upon destroy

### DIFF
--- a/src/Preview.vue
+++ b/src/Preview.vue
@@ -87,7 +87,7 @@ export default {
     this.renderComponent(this.code.trim());
   },
   destroyed() {
-    this.removeScopedStyle();
+    this.removeStyle();
   },
   watch: {
     code(value) {


### PR DESCRIPTION
`removeScopedStyle` can be `null` and `removeStyle` has guarded against that.